### PR TITLE
feat: retrieve entrypoint and command of parameterized images

### DIFF
--- a/runtimes/cloudformation/cfnpatcher/cfn_test.go
+++ b/runtimes/cloudformation/cfnpatcher/cfn_test.go
@@ -90,7 +90,8 @@ func runTest(t *testing.T, name string, context context.Context, config Configur
 	if err != nil {
 		t.Fatalf("cannot find fixtures/%s.json", name)
 	}
-	result, err := Patch(context, &config, fragment)
+	templateParameters := make([]byte, 0)
+	result, err := Patch(context, &config, fragment, templateParameters)
 	if err != nil {
 		t.Fatalf("error patching: %s", err.Error())
 	}

--- a/runtimes/cloudformation/cfnpatcher/patcher.go
+++ b/runtimes/cloudformation/cfnpatcher/patcher.go
@@ -38,7 +38,7 @@ func applyParametersPatch(ctx context.Context, template *gabs.Container, configu
 	return template, nil
 }
 
-func applyTaskDefinitionPatch(ctx context.Context, name string, resource *gabs.Container, configuration *Configuration, hints *InstrumentationHints) (*gabs.Container, error) {
+func applyTaskDefinitionPatch(ctx context.Context, name string, resource, parameters *gabs.Container, configuration *Configuration, hints *InstrumentationHints) (*gabs.Container, error) {
 	l := log.Ctx(ctx)
 
 	successes := 0
@@ -46,7 +46,7 @@ func applyTaskDefinitionPatch(ctx context.Context, name string, resource *gabs.C
 	k := kiltapi.NewKiltFromHoconWithConfig(configuration.Kilt, configuration.RecipeConfig)
 	if resource.Exists("Properties", "ContainerDefinitions") {
 		for _, container := range resource.S("Properties", "ContainerDefinitions").Children() {
-			info := extractContainerInfo(ctx, resource, name, container, configuration)
+			info := extractContainerInfo(ctx, resource, name, container, parameters, configuration)
 			l.Info().Msgf("extracted info for container: %+v %+v", info.TargetInfo, info)
 			if shouldSkip(info.TargetInfo, configuration, hints) {
 				l.Info().Msgf("skipping container due to hints in tags")

--- a/runtimes/cloudformation/cmd/cfn-apply-kilt/main.go
+++ b/runtimes/cloudformation/cmd/cfn-apply-kilt/main.go
@@ -37,7 +37,8 @@ func main() {
 	ctx := context.Background()
 	l := zerolog.New(os.Stderr).With().Timestamp().Logger()
 	ctx = l.WithContext(ctx)
-	result, err := cfnpatcher.Patch(ctx, config, template)
+	templateParameters := make([]byte, 0)
+	result, err := cfnpatcher.Patch(ctx, config, template, templateParameters)
 
 	if err != nil {
 		panic(fmt.Errorf("could not patch template: %w", err))

--- a/runtimes/cloudformation/cmd/handler/main.go
+++ b/runtimes/cloudformation/cmd/handler/main.go
@@ -58,7 +58,6 @@ func PatchLocalFile(configuration *cfnpatcher.Configuration, ctx context.Context
 		return nil, err
 	}
 
-	// TODO look for defaults, cannot do better here
 	templateParameters := make([]byte, 0)
 	result, err := cfnpatcher.Patch(loggerCtx, configuration, inputData, templateParameters)
 	if err != nil {

--- a/runtimes/cloudformation/cmd/handler/main.go
+++ b/runtimes/cloudformation/cmd/handler/main.go
@@ -16,11 +16,12 @@ import (
 )
 
 type MacroInput struct {
-	Region      string          `json:"region"`
-	AccountID   string          `json:"accountId"`
-	RequestID   string          `json:"requestId"`
-	TransformID string          `json:"transformId"`
-	Fragment    json.RawMessage `json:"fragment"`
+	Region      string                      `json:"region"`
+	AccountID   string                      `json:"accountId"`
+	RequestID   string                      `json:"requestId"`
+	TransformID string                      `json:"transformId"`
+	TemplateParameterValues json.RawMessage `json:"templateParameterValues"`
+	Fragment    json.RawMessage             `json:"fragment"`
 }
 
 type MacroOutput struct {
@@ -37,7 +38,7 @@ func HandleRequest(configuration *cfnpatcher.Configuration, ctx context.Context,
 		Str("transformId", event.TransformID).
 		Logger()
 	loggerCtx := l.WithContext(ctx)
-	result, err := cfnpatcher.Patch(loggerCtx, configuration, event.Fragment)
+	result, err := cfnpatcher.Patch(loggerCtx, configuration, event.Fragment, event.TemplateParameterValues)
 	if err != nil {
 		return MacroOutput{event.RequestID, "failure", result}, err
 	}
@@ -57,7 +58,9 @@ func PatchLocalFile(configuration *cfnpatcher.Configuration, ctx context.Context
 		return nil, err
 	}
 
-	result, err := cfnpatcher.Patch(loggerCtx, configuration, inputData)
+	// TODO look for defaults, cannot do better here
+	templateParameters := make([]byte, 0)
+	result, err := cfnpatcher.Patch(loggerCtx, configuration, inputData, templateParameters)
 	if err != nil {
 		l.Error().Err(err).Msg("failed to patch local file")
 		return nil, err

--- a/runtimes/terraform/tf/fargate.go
+++ b/runtimes/terraform/tf/fargate.go
@@ -62,7 +62,8 @@ func patchFargateTaskDefinition(ctx context.Context, containerDefinitions *types
 		}
 	}()
 
-	patchedBytes, err := cfnpatcher.Patch(ctx, kiltConfig, patchedStack)
+	templateParameters := make([]byte, 0)
+	patchedBytes, err := cfnpatcher.Patch(ctx, kiltConfig, patchedStack, templateParameters)
 	if err != nil {
 		return types.String{Unknown: true}, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR leverages the `templateParameterValues` packed in the lambda event to enable the retrieval of the entrypoint and command for parameterized images.
