### PR TITLE
refactor: export pkg as a sysdiglabs/agent-kilt module

### DIFF
--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -1,4 +1,4 @@
-module github.com/falcosecurity/kilt/pkg
+module github.com/sysdiglabs/agent-kilt/pkg
 
 go 1.18
 

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -1,4 +1,3 @@
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -9,15 +8,12 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
-github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
-github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/hocon/build.go
+++ b/pkg/hocon/build.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/go-akka/configuration"
 
-	"github.com/falcosecurity/kilt/pkg/kilt"
+	"github.com/sysdiglabs/agent-kilt/pkg/kilt"
 )
 
 func extractBuild(config *configuration.Config) (*kilt.Build, error) {

--- a/pkg/hocon/hocon.go
+++ b/pkg/hocon/hocon.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/go-akka/configuration"
 
-	"github.com/falcosecurity/kilt/pkg/kilt"
+	"github.com/sysdiglabs/agent-kilt/pkg/kilt"
 )
 
 var defaults = `

--- a/pkg/hocon/hocon_test.go
+++ b/pkg/hocon/hocon_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/falcosecurity/kilt/pkg/kilt"
+	"github.com/sysdiglabs/agent-kilt/pkg/kilt"
 )
 
 func TestSimpleRuntime(t *testing.T) {

--- a/pkg/hocon/payload.go
+++ b/pkg/hocon/payload.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/go-akka/configuration/hocon"
 
-	"github.com/falcosecurity/kilt/pkg/kilt"
+	"github.com/sysdiglabs/agent-kilt/pkg/kilt"
 )
 
 func retrievePayload(object *hocon.HoconObject) (*kilt.Payload, error) {

--- a/pkg/hocon/runtime.go
+++ b/pkg/hocon/runtime.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/go-akka/configuration"
 
-	"github.com/falcosecurity/kilt/pkg/kilt"
+	"github.com/sysdiglabs/agent-kilt/pkg/kilt"
 )
 
 func extractRuntime(config *configuration.Config) (*kilt.Runtime, error) {

--- a/pkg/kiltapi/api.go
+++ b/pkg/kiltapi/api.go
@@ -1,8 +1,8 @@
 package kiltapi
 
 import (
-	"github.com/falcosecurity/kilt/pkg/hocon"
-	"github.com/falcosecurity/kilt/pkg/kilt"
+	"github.com/sysdiglabs/agent-kilt/pkg/hocon"
+	"github.com/sysdiglabs/agent-kilt/pkg/kilt"
 )
 
 func NewKiltFromHocon(definition string) *kilt.Kilt {


### PR DESCRIPTION
**What this PR does / why we need it**:

Export pkg as a `sysdiglabs/agent-kilt` go module.

