### PR TITLE
fix: replace actions/create-release@v1 with softprops/action-gh-release@v1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Create GitHub Release
         id: create_release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
# Description

This PR replaces the (unmaintained) [actions/create-release@v1](https://github.com/actions/create-release) with [softprops/action-gh-release@v1](https://github.com/softprops/action-gh-release), which actually provides the handle `with.files` we use to populate the release with the desired artifacts.