### PR TITLE
fix: use entrypoint/command from template when possibile

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -43,8 +43,7 @@ jobs:
 
       - name: Test
         run: |
-          cd runtimes/cloudformation
-          go test -v ./...
+          make -C runtimes/cloudformation test
 
   build-cfn-runtime:
     name: Build CloudFormation runtime

--- a/runtimes/cloudformation/Makefile
+++ b/runtimes/cloudformation/Makefile
@@ -11,4 +11,7 @@ clean:
 	rm agent-kilt.zip || true
 	rm cmd/handler/handler || true
 
-.PHONY: clean
+test:
+	go test -v ./...
+
+.PHONY: clean test

--- a/runtimes/cloudformation/cfnpatcher/cfn_test.go
+++ b/runtimes/cloudformation/cfnpatcher/cfn_test.go
@@ -47,6 +47,13 @@ var defaultTests = [...]string{
 	"patching/volumes_from",
 }
 
+var enableHints = [...]string{
+	"patching/hints_no_overrides",
+	"patching/hints_override_command",
+	"patching/hints_override_entrypoint",
+	"patching/hints_override_entrypoint_command",
+}
+
 var parameterizedEnvarsTests = [...]string{
 	"patching/parameterize_env_add",
 	"patching/parameterize_env_merge",
@@ -200,6 +207,22 @@ func TestPatching(t *testing.T) {
 					OptIn:              false,
 					RecipeConfig:       "{}",
 					UseRepositoryHints: false,
+				})
+		})
+	}
+}
+
+func TestPatchingWithRepoHints(t *testing.T) {
+	l := log.Output(zerolog.ConsoleWriter{Out: os.Stderr}).With().Caller().Logger()
+
+	for _, testName := range enableHints {
+		t.Run(testName, func(t *testing.T) {
+			runTest(t, testName, l.WithContext(context.Background()),
+				Configuration{
+					Kilt:               defaultConfig,
+					OptIn:              false,
+					RecipeConfig:       "{}",
+					UseRepositoryHints: true,
 				})
 		})
 	}

--- a/runtimes/cloudformation/cfnpatcher/fixtures/patching/hints_no_overrides.json
+++ b/runtimes/cloudformation/cfnpatcher/fixtures/patching/hints_no_overrides.json
@@ -1,0 +1,18 @@
+{
+  "Resources": {
+    "taskdef": {
+      "Type": "AWS::ECS::TaskDefinition",
+      "Properties": {
+        "RequiresCompatibilities": [
+          "FARGATE"
+        ],
+        "ContainerDefinitions": [
+          {
+            "Name": "app",
+            "Image": "nginx"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/runtimes/cloudformation/cfnpatcher/fixtures/patching/hints_no_overrides.patched.json
+++ b/runtimes/cloudformation/cfnpatcher/fixtures/patching/hints_no_overrides.patched.json
@@ -1,0 +1,46 @@
+{
+  "Resources": {
+    "taskdef": {
+      "Properties": {
+        "ContainerDefinitions": [
+          {
+            "Command": [
+              "/docker-entrypoint.sh",
+              "nginx",
+              "-g",
+              "daemon off;"
+            ],
+            "EntryPoint": [
+              "/kilt/run",
+              "--"
+            ],
+            "Image": "nginx",
+            "Name": "app",
+            "LinuxParameters": {
+              "Capabilities": {
+                "Add": ["SYS_PTRACE"]
+              }
+            },
+            "VolumesFrom": [
+              {
+                "ReadOnly": true,
+                "SourceContainer": "KiltImage"
+              }
+            ]
+          },
+          {
+            "EntryPoint": [
+              "/kilt/wait"
+            ],
+            "Image": "KILT:latest",
+            "Name": "KiltImage"
+          }
+        ],
+        "RequiresCompatibilities": [
+          "FARGATE"
+        ]
+      },
+      "Type": "AWS::ECS::TaskDefinition"
+    }
+  }
+}

--- a/runtimes/cloudformation/cfnpatcher/fixtures/patching/hints_override_command.json
+++ b/runtimes/cloudformation/cfnpatcher/fixtures/patching/hints_override_command.json
@@ -1,0 +1,19 @@
+{
+  "Resources": {
+    "taskdef": {
+      "Type": "AWS::ECS::TaskDefinition",
+      "Properties": {
+        "RequiresCompatibilities": [
+          "FARGATE"
+        ],
+        "ContainerDefinitions": [
+          {
+            "Name": "app",
+            "Image": "nginx",
+            "Command": ["my-command"]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/runtimes/cloudformation/cfnpatcher/fixtures/patching/hints_override_command.patched.json
+++ b/runtimes/cloudformation/cfnpatcher/fixtures/patching/hints_override_command.patched.json
@@ -1,0 +1,44 @@
+{
+  "Resources": {
+    "taskdef": {
+      "Properties": {
+        "ContainerDefinitions": [
+          {
+            "Command": [
+              "/docker-entrypoint.sh",
+              "my-command"
+            ],
+            "EntryPoint": [
+              "/kilt/run",
+              "--"
+            ],
+            "Image": "nginx",
+            "Name": "app",
+            "LinuxParameters": {
+              "Capabilities": {
+                "Add": ["SYS_PTRACE"]
+              }
+            },
+            "VolumesFrom": [
+              {
+                "ReadOnly": true,
+                "SourceContainer": "KiltImage"
+              }
+            ]
+          },
+          {
+            "EntryPoint": [
+              "/kilt/wait"
+            ],
+            "Image": "KILT:latest",
+            "Name": "KiltImage"
+          }
+        ],
+        "RequiresCompatibilities": [
+          "FARGATE"
+        ]
+      },
+      "Type": "AWS::ECS::TaskDefinition"
+    }
+  }
+}

--- a/runtimes/cloudformation/cfnpatcher/fixtures/patching/hints_override_entrypoint.json
+++ b/runtimes/cloudformation/cfnpatcher/fixtures/patching/hints_override_entrypoint.json
@@ -1,0 +1,19 @@
+{
+  "Resources": {
+    "taskdef": {
+      "Type": "AWS::ECS::TaskDefinition",
+      "Properties": {
+        "RequiresCompatibilities": [
+          "FARGATE"
+        ],
+        "ContainerDefinitions": [
+          {
+            "Name": "app",
+            "Image": "nginx",
+            "EntryPoint": ["my-entrypoint"]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/runtimes/cloudformation/cfnpatcher/fixtures/patching/hints_override_entrypoint.patched.json
+++ b/runtimes/cloudformation/cfnpatcher/fixtures/patching/hints_override_entrypoint.patched.json
@@ -1,0 +1,43 @@
+{
+  "Resources": {
+    "taskdef": {
+      "Properties": {
+        "ContainerDefinitions": [
+          {
+            "Command": [
+              "my-entrypoint"
+            ],
+            "EntryPoint": [
+              "/kilt/run",
+              "--"
+            ],
+            "Image": "nginx",
+            "Name": "app",
+            "LinuxParameters": {
+              "Capabilities": {
+                "Add": ["SYS_PTRACE"]
+              }
+            },
+            "VolumesFrom": [
+              {
+                "ReadOnly": true,
+                "SourceContainer": "KiltImage"
+              }
+            ]
+          },
+          {
+            "EntryPoint": [
+              "/kilt/wait"
+            ],
+            "Image": "KILT:latest",
+            "Name": "KiltImage"
+          }
+        ],
+        "RequiresCompatibilities": [
+          "FARGATE"
+        ]
+      },
+      "Type": "AWS::ECS::TaskDefinition"
+    }
+  }
+}

--- a/runtimes/cloudformation/cfnpatcher/fixtures/patching/hints_override_entrypoint_command.json
+++ b/runtimes/cloudformation/cfnpatcher/fixtures/patching/hints_override_entrypoint_command.json
@@ -1,0 +1,20 @@
+{
+  "Resources": {
+    "taskdef": {
+      "Type": "AWS::ECS::TaskDefinition",
+      "Properties": {
+        "RequiresCompatibilities": [
+          "FARGATE"
+        ],
+        "ContainerDefinitions": [
+          {
+            "Name": "app",
+            "Image": "nginx",
+            "Command": ["my-command"],
+            "EntryPoint": ["my-entrypoint"]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/runtimes/cloudformation/cfnpatcher/fixtures/patching/hints_override_entrypoint_command.patched.json
+++ b/runtimes/cloudformation/cfnpatcher/fixtures/patching/hints_override_entrypoint_command.patched.json
@@ -1,0 +1,44 @@
+{
+  "Resources": {
+    "taskdef": {
+      "Properties": {
+        "ContainerDefinitions": [
+          {
+            "Command": [
+              "my-entrypoint",
+              "my-command"
+            ],
+            "EntryPoint": [
+              "/kilt/run",
+              "--"
+            ],
+            "Image": "nginx",
+            "Name": "app",
+            "LinuxParameters": {
+              "Capabilities": {
+                "Add": ["SYS_PTRACE"]
+              }
+            },
+            "VolumesFrom": [
+              {
+                "ReadOnly": true,
+                "SourceContainer": "KiltImage"
+              }
+            ]
+          },
+          {
+            "EntryPoint": [
+              "/kilt/wait"
+            ],
+            "Image": "KILT:latest",
+            "Name": "KiltImage"
+          }
+        ],
+        "RequiresCompatibilities": [
+          "FARGATE"
+        ]
+      },
+      "Type": "AWS::ECS::TaskDefinition"
+    }
+  }
+}


### PR DESCRIPTION
# What type of PR is this?

/kind bugfix

# What this PR does / why we need it:

Use the entrypoint/command overridden by the template if available.