### PR TITLE
chore: fix target branch in presubmit hook

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -2,7 +2,7 @@ name: Quality Gate
 
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ dev ]
 
 env:
   GO_VERSION: 1.20.x


### PR DESCRIPTION
# What type of PR is this?

/kind chore

# What this PR does / why we need it:

Fixes the target branch in the presubmit action.