### PR TITLE
fix(pkg): make sure the config entrypoint/cmd exist before looping over them

### DIFF
--- a/pkg/kilt/build.go
+++ b/pkg/kilt/build.go
@@ -154,9 +154,9 @@ func applyPatch(container *gabs.Container, config *configuration.Config, patchCo
 
 	entryPoint := gabs.New()
 	entryPoint.Set(make([]interface{}, 0))
-	rawEntryPoint := config.GetValue("build.entry_point").GetArray()
+	rawEntryPoint := config.GetValue("build.entry_point")
 	if rawEntryPoint != nil {
-		for _, c := range rawEntryPoint {
+		for _, c := range rawEntryPoint.GetArray() {
 			entryPoint.ArrayAppend(renderHoconValue(c))
 		}
 	}
@@ -167,9 +167,9 @@ func applyPatch(container *gabs.Container, config *configuration.Config, patchCo
 
 	command := gabs.New()
 	command.Set(make([]interface{}, 0))
-	rawCommand := config.GetValue("build.command").GetArray()
+	rawCommand := config.GetValue("build.command")
 	if rawCommand != nil {
-		for _, c := range rawCommand {
+		for _, c := range rawCommand.GetArray() {
 			command.ArrayAppend(renderHoconValue(c))
 		}
 	}


### PR DESCRIPTION
This PR fixes a potential sigsegv that may occur when the configuration gets an empty entrypoint/command.

```bash
(dlv) bt
 0  0x0000000000443ea4 in runtime.fatalpanic
    at /usr/local/go/src/runtime/panic.go:1217
...
 3  0x000000000045bdc5 in runtime.sigpanic
    at /usr/local/go/src/runtime/signal_unix.go:881
* 4  0x0000000000c842d1 in github.com/go-akka/configuration/hocon.(*HoconValue).GetArray
    at /go/pkg/mod/github.com/go-akka/configuration@v0.0.0-20200606091224-a002c0330665/hocon/value.go:370
* 5  0x0000000000c89c05 in github.com/sysdiglabs/agent-kilt/pkg/kilt.applyPatch
    at /go/pkg/mod/github.com/sysdiglabs/agent-kilt/pkg@v0.0.0-20240405134138-b9c2140c6381/kilt/build.go:157
 6  0x0000000000c8d925 in github.com/sysdiglabs/agent-kilt/pkg/kilt.(*KiltHocon).patchContainerDefinitions
    at /go/pkg/mod/github.com/sysdiglabs/agent-kilt/pkg@v0.0.0-20240405134138-b9c2140c6381/kilt/hocon.go:107
 7  0x0000000000c8e8d0 in github.com/sysdiglabs/agent-kilt/pkg/kilt.(*KiltHocon).PatchTaskDefinition
...
(dlv)
```

`pkg.kilt` got an empty array (from `config.entrypoint` in this case)
```bash
(dlv) frame 4
> [unrecovered-panic] runtime.fatalpanic() /usr/local/go/src/runtime/panic.go:1217 (hits goroutine(1):1 total:1) (PC: 0x443ea4)
Warning: debugging optimized function
Frame 4: /go/pkg/mod/github.com/go-akka/configuration@v0.0.0-20200606091224-a002c0330665/hocon/value.go:370 (PC: c842d1)
(dlv) locals
arrs = []*github.com/go-akka/configuration/hocon.HoconValue len: 0, cap: 0, nil
(dlv) args
p = *github.com/go-akka/configuration/hocon.HoconValue nil
~r0 = []*github.com/go-akka/configuration/hocon.HoconValue len: 0, cap: 0, nil
(dlv)
```

```bash
(dlv) frame 5
> [unrecovered-panic] runtime.fatalpanic() /usr/local/go/src/runtime/panic.go:1217 (hits goroutine(1):1 total:1) (PC: 0x443ea4)
Warning: debugging optimized function
Frame 5: /go/pkg/mod/github.com/sysdiglabs/agent-kilt/pkg@v0.0.0-20240405134138-b9c2140c6381/kilt/build.go:157 (PC: c89c05)
(dlv) locals
err = error nil
entryPoint = ("*github.com/Jeffail/gabs/v2.Container")(0xc0004df4f0)
(dlv) args
container = ("*github.com/Jeffail/gabs/v2.Container")(0xc0004de190)
config = ("*github.com/go-akka/configuration.Config")(0xc000262690)
patchConfig = ("*github.com/sysdiglabs/agent-kilt/pkg/kilt.PatchConfig")(0xc000527666)
~r0 = map[string]*github.com/Jeffail/gabs/v2.Container nil
~r1 = error nil
```