### PR TITLE
feat: allow setting RuntimePlatform.CpuArchitecture in the output task definition

### DIFF
--- a/pkg/kilt/hocon.go
+++ b/pkg/kilt/hocon.go
@@ -155,6 +155,14 @@ func (k *KiltHocon) PatchTaskDefinition(taskdef *gabs.Container, patchConfig *Pa
 		}
 	}
 
+	if config.HasPath("task.runtime_platform.cpu_architecture") {
+        cpuArchitecture := config.GetString("task.runtime_platform.cpu_architecture")
+        _, err = taskdef.Set(cpuArchitecture, "Properties", "RuntimePlatform", "CpuArchitecture")
+        if err != nil {
+            return fmt.Errorf("could not set the CpuArchitecture: %w", err)
+        }
+    }
+
 	containerDefinitions := taskdef.S("Properties", "ContainerDefinitions")
 	if containerDefinitions != nil {
 		err := k.patchContainerDefinitions(containerDefinitions, patchConfig, groupName, filter)

--- a/runtimes/cloudformation/cfnpatcher/cfn_test.go
+++ b/runtimes/cloudformation/cfnpatcher/cfn_test.go
@@ -66,6 +66,10 @@ var taskPidModeTests = [...]string{
 	"task_pid_mode/command",
 }
 
+var taskRuntimePlatform = [...]string{
+	"task_runtime_platform/cpu_architecture",
+}
+
 const defaultConfig = `
 build {
 	entry_point: ["/kilt/run", "--"]
@@ -136,6 +140,27 @@ build {
 }
 task {
 	pid_mode: "task"
+}
+`
+
+const taskCpuArchitecture = `
+build {
+	entry_point: ["/kilt/run", "--"]
+	command: [] ${?original.entry_point} ${?original.command}
+	mount: [
+		{
+			name: "KiltImage"
+			image: "KILT:latest"
+			volumes: ["/kilt"]
+			entry_point: ["/kilt/wait"]
+		}
+	]
+	capabilities: ["SYS_PTRACE"]
+}
+task {
+	runtime_platform {
+		cpu_architecture: "X86_64"
+	}
 }
 `
 
@@ -255,6 +280,18 @@ func TestPatchingTask(t *testing.T) {
 				})
 		})
 	}
+
+	for _, testName := range taskRuntimePlatform {
+        t.Run(testName, func(t *testing.T) {
+            runTest(t, testName, l.WithContext(context.Background()),
+                Configuration{
+                    Kilt:               taskCpuArchitecture,
+                    OptIn:              false,
+                    RecipeConfig:       "{}",
+                    UseRepositoryHints: false,
+                })
+        })
+    }
 }
 
 func TestPatchingForParameterizingEnvars(t *testing.T) {

--- a/runtimes/cloudformation/cfnpatcher/fixtures/task_runtime_platform/cpu_architecture.json
+++ b/runtimes/cloudformation/cfnpatcher/fixtures/task_runtime_platform/cpu_architecture.json
@@ -1,0 +1,29 @@
+{
+  "Resources": {
+    "taskdef": {
+      "Type": "AWS::ECS::TaskDefinition",
+      "Properties": {
+        "RequiresCompatibilities": [
+          "FARGATE"
+        ],
+        "Tags": [
+          {
+            "Key": "antani",
+            "Value": "sbiribuda"
+          },
+          {
+            "Key": "kiltinclude",
+            "Value": "itisignored"
+          }
+        ],
+        "ContainerDefinitions": [
+          {
+            "Name": "app",
+            "Image": "busybox",
+            "Command": ["/bin/sh"]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/runtimes/cloudformation/cfnpatcher/fixtures/task_runtime_platform/cpu_architecture.patched.json
+++ b/runtimes/cloudformation/cfnpatcher/fixtures/task_runtime_platform/cpu_architecture.patched.json
@@ -1,0 +1,58 @@
+{
+  "Resources": {
+    "taskdef": {
+      "Properties": {
+        "ContainerDefinitions": [
+          {
+            "Command": [
+              "/bin/sh"
+            ],
+            "EntryPoint": [
+              "/kilt/run",
+              "--"
+            ],
+            "Image": "busybox",
+            "LinuxParameters": {
+              "Capabilities": {
+                "Add": [
+                  "SYS_PTRACE"
+                ]
+              }
+            },
+            "Name": "app",
+            "VolumesFrom": [
+              {
+                "ReadOnly": true,
+                "SourceContainer": "KiltImage"
+              }
+            ]
+          },
+          {
+            "EntryPoint": [
+              "/kilt/wait"
+            ],
+            "Image": "KILT:latest",
+            "Name": "KiltImage"
+          }
+        ],
+        "RequiresCompatibilities": [
+          "FARGATE"
+        ],
+        "Tags": [
+          {
+            "Key": "antani",
+            "Value": "sbiribuda"
+          },
+          {
+            "Key": "kiltinclude",
+            "Value": "itisignored"
+          }
+        ],
+        "RuntimePlatform": {
+          "CpuArchitecture": "X86_64"
+        }
+      },
+      "Type": "AWS::ECS::TaskDefinition"
+    }
+  }
+}


### PR DESCRIPTION
This PR allows setting `RuntimePlatform.CpuArchitecture` in the output task definition.