### PR TITLE
fix: check that opt-in opt-out tests panic when using Refs

### DIFF
--- a/runtimes/cloudformation/cfnpatcher/cfn_test.go
+++ b/runtimes/cloudformation/cfnpatcher/cfn_test.go
@@ -326,7 +326,11 @@ func TestOptTagPanic(t *testing.T) {
 
 	for _, testName := range optPanicTests {
 		t.Run(testName, func(t *testing.T) {
-			defer func() { recover() }()
+			defer func() {
+				if r := recover(); r == nil {
+					t.Errorf("Expected panic for test %s but got none", testName)
+				}
+			}()
 
 			runTest(t, testName, l.WithContext(context.Background()),
 				Configuration{

--- a/runtimes/cloudformation/cfnpatcher/fixtures/respect_ignores/panic_opt_exclude.json
+++ b/runtimes/cloudformation/cfnpatcher/fixtures/respect_ignores/panic_opt_exclude.json
@@ -19,7 +19,9 @@
           },
           {
             "Key": "kilt-ignore",
-            "Value": "ignoretagisignored"
+            "Value": {
+              "Ref": "ignoretagisignored"
+            }
           }
         ],
         "ContainerDefinitions": [


### PR DESCRIPTION
Currently, agent-kilt cannot resolve `Refs` when the tag is an OptIn/OptOut value. As a result, the `Value` must be inlined.

Therefore, when a `Ref` is used with OptIn/OptOut tags, agent-kilt should panic because it cannot resolve the `Ref` and honor the configuration.

This PR:
 - Fixes the `panic_opt_exclude.json` template to trigger a panic reliably
 - Verifies that the `panic_opt` tests result in panics, as expected.