### PR TITLE
tests: add missing patched json for sidecar fixtures

### DIFF
--- a/runtimes/cloudformation/cfnpatcher/fixtures/sidecar_env/overlap.patched.json
+++ b/runtimes/cloudformation/cfnpatcher/fixtures/sidecar_env/overlap.patched.json
@@ -1,0 +1,67 @@
+{
+  "Resources": {
+    "taskdef": {
+      "Properties": {
+        "ContainerDefinitions": [
+          {
+            "Command": [
+              "/bin/sh"
+            ],
+            "EntryPoint": [
+              "/kilt/run",
+              "--"
+            ],
+            "Environment": [
+              {
+                "Name": "MEANING_OF_LIFE",
+                "Value": "forty-two"
+              }
+            ],
+            "Image": "busybox",
+            "LinuxParameters": {
+              "Capabilities": {
+                "Add": [
+                  "SYS_PTRACE"
+                ]
+              }
+            },
+            "Name": "app",
+            "VolumesFrom": [
+              {
+                "ReadOnly": true,
+                "SourceContainer": "KiltImage"
+              }
+            ]
+          },
+          {
+            "EntryPoint": [
+              "/kilt/wait"
+            ],
+            "Environment": [
+              {
+                "Name": "MEANING_OF_LIFE",
+                "Value": "42"
+              }
+            ],
+            "Image": "KILT:latest",
+            "Name": "KiltImage"
+          }
+        ],
+        "RequiresCompatibilities": [
+          "FARGATE"
+        ],
+        "Tags": [
+          {
+            "Key": "antani",
+            "Value": "sbiribuda"
+          },
+          {
+            "Key": "kiltinclude",
+            "Value": "itisignored"
+          }
+        ]
+      },
+      "Type": "AWS::ECS::TaskDefinition"
+    }
+  }
+}


### PR DESCRIPTION
We simply missed pushing the patched file.