### PR TITLE
fix(runtimes/cloudformation): do not assume images are always plain strings

### DIFF
--- a/runtimes/cloudformation/cfnpatcher/cfn_test.go
+++ b/runtimes/cloudformation/cfnpatcher/cfn_test.go
@@ -41,6 +41,7 @@ var defaultTests = [...]string{
 	"patching/ref_tags",
 	"patching/tags",
 	"patching/volumes_from",
+	"patching/dynamic_image",
 }
 
 var enableHints = [...]string{

--- a/runtimes/cloudformation/cfnpatcher/fixtures/patching/dynamic_image.json
+++ b/runtimes/cloudformation/cfnpatcher/fixtures/patching/dynamic_image.json
@@ -1,0 +1,42 @@
+{
+  "Resources": {
+    "taskdef": {
+      "Type": "AWS::ECS::TaskDefinition",
+      "Properties": {
+        "RequiresCompatibilities": [
+          "FARGATE"
+        ],
+        "Tags": [
+          {
+            "Key": "antani",
+            "Value": "sbiribuda"
+          },
+          {
+            "Key": "kiltinclude",
+            "Value": "itisignored"
+          }
+        ],
+        "ContainerDefinitions": [
+          {
+            "Name": "app",
+            "Image": {
+              "Fn::Join": [
+                "",
+                [
+                  "quak.io/gimme/",
+                  {
+                    "Fn::GetAtt": [
+                      "fried",
+                      "chicken"
+                    ]
+                  }
+                ]
+              ]
+            },
+            "Command": ["/bin/sh"]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/runtimes/cloudformation/cfnpatcher/fixtures/patching/dynamic_image.patched.json
+++ b/runtimes/cloudformation/cfnpatcher/fixtures/patching/dynamic_image.patched.json
@@ -1,0 +1,66 @@
+{
+  "Resources": {
+    "taskdef": {
+      "Properties": {
+        "ContainerDefinitions": [
+          {
+            "Command": [
+              "/bin/sh"
+            ],
+            "EntryPoint": [
+              "/kilt/run",
+              "--"
+            ],
+            "Image": {
+              "Fn::Join": [
+                "",
+                [
+                  "quak.io/gimme/",
+                  {
+                    "Fn::GetAtt": [
+                      "fried",
+                      "chicken"
+                    ]
+                  }
+                ]
+              ]
+            },
+            "Name": "app",
+            "LinuxParameters": {
+              "Capabilities": {
+                "Add": ["SYS_PTRACE"]
+              }
+            },
+            "VolumesFrom": [
+              {
+                "ReadOnly": true,
+                "SourceContainer": "KiltImage"
+              }
+            ]
+          },
+          {
+            "EntryPoint": [
+              "/kilt/wait"
+            ],
+            "Image": "KILT:latest",
+            "Name": "KiltImage"
+          }
+        ],
+        "RequiresCompatibilities": [
+          "FARGATE"
+        ],
+        "Tags": [
+          {
+            "Key": "antani",
+            "Value": "sbiribuda"
+          },
+          {
+            "Key": "kiltinclude",
+            "Value": "itisignored"
+          }
+        ]
+      },
+      "Type": "AWS::ECS::TaskDefinition"
+    }
+  }
+}

--- a/runtimes/cloudformation/cfnpatcher/template.go
+++ b/runtimes/cloudformation/cfnpatcher/template.go
@@ -2,6 +2,7 @@ package cfnpatcher
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/Jeffail/gabs/v2"
@@ -23,6 +24,7 @@ func fillContainerInfo(ctx context.Context, container *gabs.Container, parameter
 	}
 
 	var image string
+	// If the image is a reference to a parameter, resolve it
 	if container.Exists("Image", "Ref") {
 		l.Info().Str("image", container.S("Image").String()).Msg("retrieving image from template parameters")
 
@@ -38,14 +40,22 @@ func fillContainerInfo(ctx context.Context, container *gabs.Container, parameter
 			l.Warn().Str("image", container.S("Image").String()).Msg("could not find the name of the image parameter")
 		}
 	} else {
-		image = container.S("Image").Data().(string)
+		tag := container.S("Image").Data()
+		switch v := tag.(type) {
+		case string:
+			// If the image is a string, use it as is
+			image = v
+		default:
+			// Otherwise, convert it to a raw string
+			image = fmt.Sprintf("%v", v)
+		}
 	}
 
 	if configuration.UseRepositoryHints {
 		os.Setenv("HOME", "/tmp") // crane requires $HOME variable
 		repoInfo, err := GetConfigFromRepository(image)
 		if err != nil {
-			l.Warn().Str("image", image).Err(err).Msg("could not retrieve metadata from repository")
+			l.Err(err).Msg("The entrypoint and command of the image must be manually set in the original template")
 		} else {
 			// Use the image's entrypoint if the task definition does not override it
 			if repoInfo.Entrypoint != nil && !hasOverriddenEntrypoint {


### PR DESCRIPTION
We cannot assume that images are always plain strings, nor can we always expect to resolve them, as users may use SSM or other CloudFormation mechanisms to construct the image name.

At the very least, avoid panicking and attempt to handle the image name gracefully.